### PR TITLE
feat: GitHub Actions를 이용한 EC2 배포 자동화 워크플로 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Executing remote ssh commands
+        uses: appleboy/ssh-action@v0.1.6
+        with:
+          host: ${{ secrets.REMOTE_IP }}
+          username: ${{ secrets.REMOTE_USER }}
+          key: ${{ secrets.REMOTE_PRIVATE_KEY }}
+          port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            cd /home/ubuntu/Server-V2
+            git pull origin main
+            npm install --force
+            npm run build
+            pm2 reload joiepot-app || pm2 start npm --name "joiepot-app" -- run start:prod

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start:local": "cross-env NODE_ENV=local nest start --watch",
     "start:dev": "cross-env NODE_ENV=dev nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "cross-env NODE_ENV=prod node dist/main",
     "db:reset": "prisma migrate reset",
     "db:push": "prisma db push",
     "db:seed": "ts-node ./prisma/seed.ts",


### PR DESCRIPTION
## 개요
- GitHub Actions를 활용하여 main 브랜치에 push 또는 PR 발생 시 EC2 서버에 자동 배포가 진행되도록 워크플로를 추가했습니다.

## 주요 변경사항
- `.github/workflows/ci.yml` 파일 추가
- appleboy/ssh-action을 이용한 원격 서버 배포 자동화
- pm2를 이용한 서비스 자동 재시작

## 참고
- GitHub Secrets에 필요한 변수(REMOTE_IP, REMOTE_USER, REMOTE_PRIVATE_KEY, REMOTE_SSH_PORT) 등록 필요

## 기타
- 추가 개선점이나 버그 발견 시 피드백 부탁드립니다.