### PR TITLE
feat(uploadfile): NODE_ENV 환경 prod로 간소화 및 분기 간결화 기존 파일 업로드 서비스에서 환경 변수(NODE_ENV) 분기를 "production"이 아닌 "prod"와 비교하도록 변경하였습니다.

### DIFF
--- a/src/uploadfile/uploadfile.service.ts
+++ b/src/uploadfile/uploadfile.service.ts
@@ -27,11 +27,6 @@ export class UploadfileService {
 
   /**
    * 실제 파일 업로드 처리 및 파일 정보 DB 저장
-   * @param uploadFile 업로드된 파일 객체 (Multer)
-   * @param uploadDto 업로드 파일 DTO (contentType, contentId)
-   * @returns 업로드된 파일 정보 ({ id, name, type, url, size })
-   * @throws BadRequestException contentType/contentId 누락, 존재하지 않는 엔티티, 유효하지 않은 타입 등
-   * @throws InternalServerErrorException 업로드 실패
    */
   async fileUpload(uploadFile: Express.Multer.File, uploadDto: UploadFileDto) {
     let uploadFilePath: string | null = null;
@@ -93,11 +88,10 @@ export class UploadfileService {
         },
       });
 
-      // 환경에 따라 urlForDb 결정
+      // prod 환경이 아니면 localhost URL 사용, prod면 storage 리턴 URL 사용
+      const nodeEnv = (this.configService.get('NODE_ENV') || '').toLowerCase();
       let urlForDb = uploadFilePath;
-      const nodeEnv = this.configService.get('NODE_ENV');
-      const port = this.configService.get('APP_PORT') || 8000;
-      if (nodeEnv !== 'production' && uploadFilePath) {
+      if (nodeEnv !== 'prod' && uploadFilePath) {
         let relativeUrl: string;
         if (uploadFilePath.startsWith('/uploads/')) {
           relativeUrl = uploadFilePath;
@@ -106,6 +100,7 @@ export class UploadfileService {
         } else {
           relativeUrl = '/uploads/' + uploadFilePath.replace(/^\/+/, '');
         }
+        const port = this.configService.get('APP_PORT') || 8000;
         urlForDb = `http://localhost:${port}${relativeUrl}`;
       }
 


### PR DESCRIPTION
### 주요 변경 내용
- NODE_ENV가 'prod'가 아닐 때만 localhost URL을 사용하도록 분기 처리
- 기존의 "production" 문자열 비교를 "prod"로만 간소화하여 배포 운영 환경에서의 혼란 방지
- 그 외 업로드 및 파일 정보 저장, 기존 파일 처리 로직 등은 기존과 동일하게 동작

이 PR은 운영 환경에서 NODE_ENV를 'prod'로 사용하고 있는 환경에 맞춰 로직을 일관성 있게 유지하기 위함입니다.