### PR TITLE
chore(ci): Pull Request 단계 스크립트 제거 및 uploadfile NODE_ENV prod 분기 간소화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: Deploy to EC2
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   deploy:

--- a/src/uploadfile/uploadfile.service.ts
+++ b/src/uploadfile/uploadfile.service.ts
@@ -27,11 +27,6 @@ export class UploadfileService {
 
   /**
    * 실제 파일 업로드 처리 및 파일 정보 DB 저장
-   * @param uploadFile 업로드된 파일 객체 (Multer)
-   * @param uploadDto 업로드 파일 DTO (contentType, contentId)
-   * @returns 업로드된 파일 정보 ({ id, name, type, url, size })
-   * @throws BadRequestException contentType/contentId 누락, 존재하지 않는 엔티티, 유효하지 않은 타입 등
-   * @throws InternalServerErrorException 업로드 실패
    */
   async fileUpload(uploadFile: Express.Multer.File, uploadDto: UploadFileDto) {
     let uploadFilePath: string | null = null;
@@ -93,11 +88,10 @@ export class UploadfileService {
         },
       });
 
-      // 환경에 따라 urlForDb 결정
+      // prod 환경이 아니면 localhost URL 사용, prod면 storage 리턴 URL 사용
+      const nodeEnv = (this.configService.get('NODE_ENV') || '').toLowerCase();
       let urlForDb = uploadFilePath;
-      const nodeEnv = this.configService.get('NODE_ENV');
-      const port = this.configService.get('APP_PORT') || 8000;
-      if (nodeEnv !== 'production' && uploadFilePath) {
+      if (nodeEnv !== 'prod' && uploadFilePath) {
         let relativeUrl: string;
         if (uploadFilePath.startsWith('/uploads/')) {
           relativeUrl = uploadFilePath;
@@ -106,6 +100,7 @@ export class UploadfileService {
         } else {
           relativeUrl = '/uploads/' + uploadFilePath.replace(/^\/+/, '');
         }
+        const port = this.configService.get('APP_PORT') || 8000;
         urlForDb = `http://localhost:${port}${relativeUrl}`;
       }
 


### PR DESCRIPTION
### 주요 변경 내용
- CI 스크립트에서 Pull Request 발생 시 동작하던 단계를 제거하여 불필요한 작업을 줄이고 워크플로우를 간소화하였습니다.
- 파일 업로드 서비스(uploadfile)에서 NODE_ENV 환경변수 분기를 "production"이 아닌 "prod"와 비교하도록 변경하였습니다.
  - NODE_ENV가 'prod'가 아닐 때만 localhost URL을 사용하도록 분기 처리
  - 운영 환경에서 NODE_ENV를 'prod'로 사용하는 상황에 맞게 로직을 일관성 있게 유지
